### PR TITLE
Auto Backfilling

### DIFF
--- a/.github/workflows/pull-data.yml
+++ b/.github/workflows/pull-data.yml
@@ -18,6 +18,8 @@ jobs:
           node-version: '20.x'
       - run: yarn
       - uses: actions/github-script@v7
+        env:
+          BACKFILL_LIMIT: ${{ vars.BACKFILL_LIMIT }}
         with:
           script: |
             const { default: run } = await import('${{ github.workspace }}/pull-data.mjs')

--- a/pull-data.mjs
+++ b/pull-data.mjs
@@ -229,10 +229,10 @@ export default async function run({ github, context, dryRun = false }) {
 
   const releasesToProcess = [...newReleases, ...backfillReleases];
 
-  for (const release of releasesToProcess) {
+  for (const [releaseIndex, release] of releasesToProcess.entries()) {
     const { tag_name } = release;
     const pathBase = `data/${tag_name}`;
-    console.group(`Processing ${tag_name}...`);
+    console.group(`(${releaseIndex+1}/${releasesToProcess.length}) Processing ${tag_name}...`);
     if (forbiddenTags.includes(tag_name)) {
       console.log(`Skipping ${tag_name} because it's on the forbidden list.`);
       continue;

--- a/pull-data.mjs
+++ b/pull-data.mjs
@@ -363,7 +363,9 @@ export default async function run({ github, context, dryRun = false }) {
     return;
   }
 
-  const builds = existingBuilds.concat(newBuilds);
+  const builds = existingBuilds
+    .filter((b1) => !newBuilds.some((b2) => b2.build_number === b1.build_number))
+    .concat(newBuilds);
 
   builds.sort((a, b) => b.created_at.localeCompare(a.created_at));
 

--- a/pull-data.mjs
+++ b/pull-data.mjs
@@ -200,6 +200,7 @@ export default async function run({ github, context, dryRun = false }) {
    *  build_number: string,
    *  prerelease: boolean,
    *  created_at: string,
+   *  updated_at?: string,
    *  langs: string[],
    *  version?: number
    * }[]}
@@ -352,6 +353,7 @@ export default async function run({ github, context, dryRun = false }) {
       build_number: tag_name,
       prerelease: release.prerelease,
       created_at: release.created_at,
+      updated_at: release.created_at,
       langs,
       version: buildVersion,
     });
@@ -363,10 +365,16 @@ export default async function run({ github, context, dryRun = false }) {
     return;
   }
 
-  const builds = existingBuilds
-    .filter((b1) => !newBuilds.some((b2) => b2.build_number === b1.build_number))
-    .concat(newBuilds);
-
+  const builds = [...existingBuilds]
+  for (const b of newBuilds) {
+    const index = builds.findIndex((b2) => b2.build_number === b.build_number);
+    if (index !== -1) {
+      b.created_at = builds[index].created_at;
+      builds[index] = b;
+    } else {
+      builds.push(b);
+    }
+  }
   builds.sort((a, b) => b.created_at.localeCompare(a.created_at));
 
   console.log(`Writing ${builds.length} builds to builds.json...`);

--- a/pull-data.mjs
+++ b/pull-data.mjs
@@ -214,6 +214,7 @@ export default async function run({ github, context, dryRun = false }) {
   const newReleases = releases.filter(
     (r) => !existingBuilds.some((b) => b.build_number === r.tag_name),
   );
+  console.log(`Found ${newReleases.length} new releases.`);
 
   const backfillReleases = (await Promise.all(
     existingBuilds
@@ -224,6 +225,7 @@ export default async function run({ github, context, dryRun = false }) {
         tag: b.build_number,
       }))
   )).filter(r => r.status === 200).map(r => r.data);
+  console.log(`Found ${backfillReleases.length} releases to backfill.`);
 
   const releasesToProcess = [...newReleases, ...backfillReleases];
 

--- a/pull-data.mjs
+++ b/pull-data.mjs
@@ -106,7 +106,7 @@ export default async function run({ github, context, dryRun = false }) {
   }
   const dataBranch = "main";
 
-  const generatedVersion = 1;
+  const buildVersion = 1;
 
   console.log("Fetching release list...");
 
@@ -216,7 +216,7 @@ export default async function run({ github, context, dryRun = false }) {
 
   const backfillReleases = (await Promise.all(
     existingBuilds
-      .filter((b) => (b.version ?? 0) < generatedVersion)
+      .filter((b) => (b.version ?? 0) < buildVersion)
       .slice(0, parseInt(process.env.BACKFILL_LIMIT ?? "30"))
       .map((b) => github.rest.repos.getReleaseByTag({
         ...dataRepo,
@@ -353,7 +353,7 @@ export default async function run({ github, context, dryRun = false }) {
       prerelease: release.prerelease,
       created_at: release.created_at,
       langs,
-      version: generatedVersion,
+      version: buildVersion,
     });
     console.groupEnd();
   }

--- a/pull-data.mjs
+++ b/pull-data.mjs
@@ -269,10 +269,10 @@ export default async function run({ github, context, dryRun = false }) {
   )).filter(r => r.status === 200).map(r => r.data);
   console.log(`Found ${backfillReleases.length} releases to backfill.`);
 
-  const releasesToProcess = [...missingReleases, ...backfillReleases];
-
   // Process at most 4 missing releases per run.
-  for (const [releaseIndex, release] of releasesToProcess.slice(0, 4).entries()) {
+  const releasesToProcess = [...missingReleases, ...backfillReleases].slice(0, 4);
+
+  for (const [releaseIndex, release] of releasesToProcess.entries()) {
     const { tag_name } = release;
     const pathBase = `data/${tag_name}`;
     console.group(`(${releaseIndex+1}/${releasesToProcess.length}) Processing ${tag_name}...`);


### PR DESCRIPTION
this PR addresses the backfilling issue mentioned in #2 by implementing the following changes:

- adds a `version` field to builds in `builds.json`, which will be recorded starting with this change (`const buildVersion = 1;`)
- on each run, the action will now identify previous builds with a lower version than the current one and perform backfilling (up to the `BACKFILL_LIMIT`)
